### PR TITLE
13 unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,13 @@
 module d7024e
 
 go 1.22.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc // indirect
+	golang.org/x/tools/cmd/cover v0.1.0-deprecated // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,10 @@ module d7024e
 
 go 1.22.1
 
+require github.com/stretchr/testify v1.9.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
-	golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc // indirect
-	golang.org/x/tools/cmd/cover v0.1.0-deprecated // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc h1:zRn9MzwG18RZhyanShCfUwJTcobvqw8fOjjROFN9jtM=
+golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
+golang.org/x/tools/cmd/cover v0.1.0-deprecated h1:Rwy+mWYz6loAF+LnG1jHG/JWMHRMMC2/1XX3Ejkx9lA=
+golang.org/x/tools/cmd/cover v0.1.0-deprecated/go.mod h1:hMDiIvlpN1NoVgmjLjUJE9tMHyxHjFX7RuQ+rW12mSA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc h1:zRn9MzwG18RZhyanShCfUwJTcobvqw8fOjjROFN9jtM=
-golang.org/x/tools v0.5.1-0.20230111220935-a7f7db3f17fc/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
-golang.org/x/tools/cmd/cover v0.1.0-deprecated h1:Rwy+mWYz6loAF+LnG1jHG/JWMHRMMC2/1XX3Ejkx9lA=
-golang.org/x/tools/cmd/cover v0.1.0-deprecated/go.mod h1:hMDiIvlpN1NoVgmjLjUJE9tMHyxHjFX7RuQ+rW12mSA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/kademlia/bucket_test.go
+++ b/kademlia/bucket_test.go
@@ -1,0 +1,45 @@
+package kademlia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucket(t *testing.T) {
+	// Create a new bucket
+	bucket := newBucket()
+
+	// Create a new contact
+	contact1 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
+	contact2 := NewContact(NewKademliaID("11111111000000000000000000000000000000000"), "localhost:8000")
+	contact3 := NewContact(NewKademliaID("22222222000000000000000000000000000000000"), "localhost:8000")
+
+	t.Run("Test AddContact", func(t *testing.T) {
+		// Add a contact to the bucket
+		bucket.AddContact(contact1)
+
+		// Check if the contact has been added to the bucket
+		if bucket.Len() != 1 {
+			t.Fatalf("Expected 1 contact but instead got %d", bucket.Len())
+		}
+
+		// Add another contact to the bucket
+		bucket.AddContact(contact2)
+		bucket.AddContact(contact3)
+		if bucket.Len() != 3 {
+			t.Fatalf("Expected 3 contact but instead got %d", bucket.Len())
+		}
+	})
+
+	t.Run("Test GetContactAndCalcDistance", func(t *testing.T) {
+		// Get a contact from the bucket
+		contacts := bucket.GetContactAndCalcDistance(NewKademliaID("0000000000000000000000000000000000000000"))
+
+		assert.Equal(t, 3, len(contacts))
+
+		assert.Equal(t, contacts[2].distance, contact1.ID)
+		assert.Equal(t, contacts[1].distance, contact2.ID)
+		assert.Equal(t, contacts[0].distance, contact3.ID)
+	})
+}

--- a/kademlia/contacts_test.go
+++ b/kademlia/contacts_test.go
@@ -1,0 +1,33 @@
+package kademlia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContacts(t *testing.T) {
+	// Create a new contact
+	contact1 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
+	contact2 := NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8000")
+	contact3 := NewContact(NewKademliaID("2222222200000000000000000000000000000000"), "localhost:8000")
+
+	t.Run("Test CalcDistance", func(t *testing.T) {
+		contact1.CalcDistance(contact2.ID)
+		assert.Equal(t, contact1.distance, NewKademliaID("EEEEEEEE00000000000000000000000000000000"))
+
+		contact2.CalcDistance(contact3.ID)
+		assert.Equal(t, contact2.distance, NewKademliaID("3333333300000000000000000000000000000000"))
+	})
+
+	t.Run("Test Less", func(t *testing.T) {
+		assert.False(t, contact1.Less(&contact2))
+		assert.True(t, contact2.Less(&contact1))
+	})
+
+	t.Run("Test String", func(t *testing.T) {
+		assert.Equal(t, contact1.String(), `contact("ffffffff00000000000000000000000000000000", "localhost:8000")`)
+		assert.Equal(t, contact2.String(), `contact("1111111100000000000000000000000000000000", "localhost:8000")`)
+		assert.Equal(t, contact3.String(), `contact("2222222200000000000000000000000000000000", "localhost:8000")`)
+	})
+}

--- a/kademlia/kademlia.go
+++ b/kademlia/kademlia.go
@@ -106,6 +106,8 @@ func (kademlia *Kademlia) LookupContact(target *KademliaID) ([]Contact, error) {
 		}
 	}
 
+	//TODO: sort the contacts?
+
 	return closestNodes, nil
 }
 

--- a/kademlia/kademlia.go
+++ b/kademlia/kademlia.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 )
 
@@ -29,7 +31,18 @@ func (kademlia *Kademlia) Start() {
 			kademlia.JoinNetwork(&kademlia.BootstrapNode)
 		}()
 	}
-	err := kademlia.Network.Listen("0.0.0.0", 3000)
+
+	host, portStr, err := net.SplitHostPort(kademlia.Me.Address)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		fmt.Println("Error converting port to int:", err)
+		return
+	}
+	err = kademlia.Network.Listen(host, port)
 	if err != nil {
 		panic(err)
 	}
@@ -53,7 +66,6 @@ func (kademlia *Kademlia) JoinNetwork(knownNode *Contact) {
 
 	fmt.Println("Network joined.")
 	kademlia.PopulateNetwork()
-	fmt.Printf("kademlia.Network.RoutingTable.buckets: %v\n", kademlia.Network.RoutingTable.buckets)
 }
 
 func (kademlia *Kademlia) PopulateNetwork() {
@@ -106,6 +118,7 @@ func (kademlia *Kademlia) LookupContact(target *KademliaID) ([]Contact, error) {
 		}
 	}
 
+	
 	//TODO: sort the contacts?
 
 	return closestNodes, nil

--- a/kademlia/kademlia_test.go
+++ b/kademlia/kademlia_test.go
@@ -1,0 +1,40 @@
+package kademlia
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKademlia(t *testing.T) {
+	bootstrapContact := NewContact(NewKademliaID("B0075712A9000000000000000000000000000000"), "localhost:3100")
+	contact := NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:3101")
+	
+	bootstrap := NewKademlia(bootstrapContact, true)
+	assert.Equal(t, bootstrap.Me.ID, bootstrapContact.ID)
+	assert.Equal(t, bootstrap.Me.Address, bootstrapContact.Address)
+	assert.Nil(t, bootstrap.BootstrapNode.ID)
+	assert.True(t, bootstrap.IsBootstrap)
+	go bootstrap.Start()
+
+	node := NewKademlia(contact, false)
+	assert.Equal(t, node.Me.ID, contact.ID)
+	assert.Equal(t, node.Me.Address, contact.Address)
+	assert.Nil(t, node.BootstrapNode.ID)
+	assert.False(t, node.IsBootstrap)
+
+	node.BootstrapNode = bootstrapContact
+	assert.Equal(t, node.BootstrapNode, bootstrapContact)
+
+	go node.Start()
+
+	t.Run("Test LookupContact", func(t *testing.T) {
+		time.Sleep(5 * time.Second)
+		contacts, err := node.LookupContact(NewKademliaID("B0075712A9000000000000000000000000000000"))
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(contacts))
+		fmt.Println(contacts)
+	})
+}

--- a/kademlia/kademliaid_test.go
+++ b/kademlia/kademliaid_test.go
@@ -1,0 +1,66 @@
+package kademlia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKademliaId(t *testing.T) {
+	// Create a new KademliaID
+
+	t.Run("Test NewKademliaID", func(t *testing.T) {
+		// Testing equality of two KademliaIDs
+		id1 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		id2 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		assert.Equal(t, id1, id2)
+
+		// Testing inequality of two KademliaIDs
+		id3 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		id4 := NewKademliaID("1111111100000000000000000000000000000000")
+		assert.NotEqual(t, id3, id4)
+	})
+
+	t.Run("Test NewRandomKademliaID", func(t *testing.T) {
+		// Testing inequality of two random KademliaIDs
+		id1 := NewRandomKademliaID()
+		id2 := NewRandomKademliaID()
+		assert.NotEqual(t, id1, id2)
+	})
+
+	t.Run("Test Less", func(t *testing.T) {
+		// Testing Less method of KademliaID
+		id1 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		id2 := NewKademliaID("1111111100000000000000000000000000000000")
+		assert.True(t, id2.Less(id1))
+		assert.False(t, id1.Less(id2))
+	})
+
+	t.Run("Test Equals", func(t *testing.T) {
+		// Testing Equals method of KademliaID
+		id1 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		id2 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		assert.True(t, id1.Equals(id2))
+
+		id3 := NewKademliaID("1111111100000000000000000000000000000000")
+		assert.False(t, id1.Equals(id3))
+	})
+
+	t.Run("Test CalcDistance", func(t *testing.T) {
+		// Testing CalcDistance method of KademliaID
+		id1 := NewKademliaID("F000000000000000000000000000000000000000")
+		id2 := NewKademliaID("1000000000000000000000000000000000000000")
+		assert.Equal(t, id1.CalcDistance(id2), NewKademliaID("E000000000000000000000000000000000000000"))
+		
+		id3 := NewKademliaID("0000000000000000000000000000000000000000")
+		assert.Equal(t, id1.CalcDistance(id1), id3)
+	})
+
+	t.Run("Test String", func(t *testing.T) {
+		// Testing String method of KademliaID
+		id1 := NewKademliaID("FFFFFFFF00000000000000000000000000000000")
+		// OBS: String() returns lower case
+		assert.Equal(t, id1.String(), "ffffffff00000000000000000000000000000000")
+
+	})
+}

--- a/kademlia/messageHandler.go
+++ b/kademlia/messageHandler.go
@@ -2,6 +2,7 @@ package kademlia
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 )
@@ -16,7 +17,6 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 
 	switch msg.MsgType {
 	case "PING":
-		fmt.Println("Received PING from ", msg.Sender)
 		response := network.handlePingMessage()
 		responseBytes, err := json.Marshal(response)
 		if err != nil {
@@ -25,7 +25,6 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 		}
 		return responseBytes, nil
 	case "JOIN":
-		fmt.Println("Received JOIN from ", msg.Sender)
 		response := network.handleJoinMessage(msg.Sender)
 		responseBytes, err := json.Marshal(response)
 		if err != nil {
@@ -34,7 +33,6 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 		}
 		return responseBytes, nil
 	case "FIND_CONTACT":
-		fmt.Println("Received FIND_CONTACT from ", msg.Sender)
 		target := NewKademliaID(msg.Content)
 		contacts := network.handleFindContactMessage(target, 3)
 		contactsBytes, err := json.Marshal(contacts)
@@ -44,11 +42,12 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 		}
 		return contactsBytes, nil
 	case "STORE":
-		fmt.Println("Received STORE from ", msg.Sender)
+		fmt.Println("Received STORE from ", msg.Sender, "NOT IMPLEMENTED")
+		network.handleStoreMessage()
 	case "FIND_VALUE":
-		fmt.Println("Received FIND_VALUE from ", msg.Sender)
+		fmt.Println("Received FIND_VALUE from ", msg.Sender, "NOT IMPLEMENTED")
 	default:
-		fmt.Println("Unknown message type: " + msg.MsgType)
+		return nil, errors.New("Unknown message type: " + msg.MsgType)
 	}
 	return nil, nil
 }
@@ -57,6 +56,7 @@ func (network *Network) handlePingMessage() Message {
 	pong := Message{
 		MsgType: "PONG",
 		Content: "I'm alive",
+		Sender:  network.Me,
 	}
 	return pong
 }

--- a/kademlia/messageHandler.go
+++ b/kademlia/messageHandler.go
@@ -17,7 +17,7 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 	switch msg.MsgType {
 	case "PING":
 		fmt.Println("Received PING from ", msg.Sender)
-		response := network.HandlePingMessage()
+		response := network.handlePingMessage()
 		responseBytes, err := json.Marshal(response)
 		if err != nil {
 			fmt.Println("Error marshalling response")
@@ -26,7 +26,7 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 		return responseBytes, nil
 	case "JOIN":
 		fmt.Println("Received JOIN from ", msg.Sender)
-		response := network.HandleJoinMessage(msg.Sender)
+		response := network.handleJoinMessage(msg.Sender)
 		responseBytes, err := json.Marshal(response)
 		if err != nil {
 			fmt.Println("Error marshalling response")
@@ -36,7 +36,7 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 	case "FIND_CONTACT":
 		fmt.Println("Received FIND_CONTACT from ", msg.Sender)
 		target := NewKademliaID(msg.Content)
-		contacts := network.HandleFindContactMessage(target, 3)
+		contacts := network.handleFindContactMessage(target, 3)
 		contactsBytes, err := json.Marshal(contacts)
 		if err != nil {
 			fmt.Println("Error marshalling contacts")
@@ -53,7 +53,7 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 	return nil, nil
 }
 
-func (network *Network) HandlePingMessage() Message {
+func (network *Network) handlePingMessage() Message {
 	pong := Message{
 		MsgType: "PONG",
 		Content: "I'm alive",
@@ -61,7 +61,7 @@ func (network *Network) HandlePingMessage() Message {
 	return pong
 }
 
-func (network *Network) HandleJoinMessage(sender Contact) Message {
+func (network *Network) handleJoinMessage(sender Contact) Message {
 	network.RoutingTable.AddContact(sender)
 	joinResponse := Message{
 		MsgType: "JOIN_RESPONSE",
@@ -70,12 +70,12 @@ func (network *Network) HandleJoinMessage(sender Contact) Message {
 	return joinResponse
 }
 
-func (network *Network) HandleFindContactMessage(target *KademliaID, count int) []Contact {
+func (network *Network) handleFindContactMessage(target *KademliaID, count int) []Contact {
 	contacts := network.RoutingTable.FindClosestContacts(target, count)
 	return contacts
 }
 
-func (network *Network) HandleStoreMessage() Message {
+func (network *Network) handleStoreMessage() Message {
 	storedmsg := Message{
 		MsgType: "STORED",
 		Content: "Data stored successfully on node",

--- a/kademlia/messageHandler_test.go
+++ b/kademlia/messageHandler_test.go
@@ -1,0 +1,32 @@
+package kademlia
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleMessage(t *testing.T) {
+	// Create a new network
+	network := NewNetwork(NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000"))	
+	// Create a new message
+
+	t.Run("Test PING message", func(t *testing.T) {
+		msg := Message{
+			MsgType: "PING",
+			Sender: NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8001"),
+			
+		}
+		data, _ := json.Marshal(msg)
+		respData, err := network.HandleMessage(data, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, respData)
+
+		var respMsg Message
+		err = json.Unmarshal(respData, &respMsg)
+		assert.Nil(t, err)
+		assert.Equal(t, "PONG", respMsg.MsgType)
+	})
+
+}

--- a/kademlia/messageHandler_test.go
+++ b/kademlia/messageHandler_test.go
@@ -9,14 +9,18 @@ import (
 
 func TestHandleMessage(t *testing.T) {
 	// Create a new network
-	network := NewNetwork(NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000"))	
+	sender := NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8001")
+	target := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8002")
+	network := NewNetwork(target)
+
 	// Create a new message
 
 	t.Run("Test PING message", func(t *testing.T) {
 		msg := Message{
 			MsgType: "PING",
-			Sender: NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8001"),
-			
+			Sender: sender,
+			Target: target,
+
 		}
 		data, _ := json.Marshal(msg)
 		respData, err := network.HandleMessage(data, nil)
@@ -28,5 +32,91 @@ func TestHandleMessage(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "PONG", respMsg.MsgType)
 	})
+
+	t.Run("Test JOIN message", func(t *testing.T) {
+		msg := Message{
+			MsgType: "JOIN",
+			Content: sender.ID.String(),
+			Sender: sender,
+			Target: target,
+		}
+
+		data, _ := json.Marshal(msg)
+		respData, err := network.HandleMessage(data, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, respData)
+
+		//TODO:  checks that the sender has been added to the routing table
+		var respMsg Message
+		err = json.Unmarshal(respData, &respMsg)
+		assert.Nil(t, err)
+		assert.Equal(t, "JOIN_RESPONSE", respMsg.MsgType)
+	})
+
+	t.Run("Test FIND_CONTACT message", func(t *testing.T) {
+		network.RoutingTable.AddContact(NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8002")) //000
+		network.RoutingTable.AddContact(NewContact(NewKademliaID("1111111100000000000000000000000000000001"), "localhost:8002")) //001
+		network.RoutingTable.AddContact(NewContact(NewKademliaID("1111111100000000000000000000000000000002"), "localhost:8002")) //010
+		network.RoutingTable.AddContact(NewContact(NewKademliaID("1111111100000000000000000000000000000003"), "localhost:8002")) //011
+		network.RoutingTable.AddContact(NewContact(NewKademliaID("1111111100000000000000000000000000000004"), "localhost:8002")) //100
+
+		msg := Message{
+			MsgType: "FIND_CONTACT",
+			Content: "1111111100000000000000000000000000000002",
+			Sender: sender,
+			Target: target,
+		}
+		data, _ := json.Marshal(msg)
+		respData, err := network.HandleMessage(data, nil)
+		assert.Nil(t, err)
+		assert.NotNil(t, respData)
+		var respContacts []Contact
+		err = json.Unmarshal(respData, &respContacts)
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(respContacts))
+		assert.Contains(t, respContacts, NewContact(NewKademliaID("1111111100000000000000000000000000000002"), "localhost:8002"))
+	})
+
+	t.Run("Test STORE message", func(t *testing.T) {
+		msg := Message{
+			MsgType: "STORE",
+			Content: "Hello World",
+			Sender: sender,
+			Target: target,
+		}
+		data, _ := json.Marshal(msg)
+		respData, err := network.HandleMessage(data, nil)
+		assert.Nil(t, err)
+		assert.Nil(t, respData)
+		//TODO check responseData
+	})
+
+	t.Run("Test FIND_VALUE message", func(t *testing.T) {
+		msg := Message{
+			MsgType: "FIND_VALUE",
+			Content: "Hello World",
+			Sender: sender,
+			Target: target,
+		}
+		data, _ := json.Marshal(msg)
+		respData, err := network.HandleMessage(data, nil)
+		assert.Nil(t, err)
+		assert.Nil(t, respData)
+		//TODO check responseData
+	})
+
+	t.Run("Test unknown message", func(t *testing.T) {
+		msg := Message{
+			MsgType: "UNKNOWN",
+			Sender: sender,
+			Target: target,
+		}
+		data, _ := json.Marshal(msg)
+		respData, err := network.HandleMessage(data, nil)
+		assert.NotNil(t, err)
+		assert.Equal(t, "Unknown message type: UNKNOWN", err.Error())
+		assert.Nil(t, respData)
+	})
+
 
 }

--- a/kademlia/network.go
+++ b/kademlia/network.go
@@ -152,28 +152,6 @@ func (network *Network) SendFindContactMessage(contact *Contact, targetID *Kadem
 
 }
 
-func (network *Network) SendFindDataMessage(hash string, contact *Contact) (string, bool) {
-	msg := Message{
-		MsgType: "FIND",
-		Content: hash,
-		Sender:  network.RoutingTable.me,
-		Target:  *contact,
-	}
-	response, err := network.sendMessage(msg, contact)
-	if err != nil {
-		return ("Failed to contact target node."), false
-	}
-	var dataResponse string
-	err = json.Unmarshal(response, &dataResponse)
-	if err != nil {
-		return "Error during unmarshalling", false
-	} else if dataResponse == "" {
-		return "Data not found", false
-	} else {
-		return dataResponse, true
-	}
-}
-
 func (network *Network) SendStoreMessage(data []byte, key string, contact *Contact) bool { //förslag, använd error istället för bools
 
 	msg := Message{
@@ -201,3 +179,27 @@ func (network *Network) SendStoreMessage(data []byte, key string, contact *Conta
 	}
 
 }
+
+func (network *Network) SendFindDataMessage(hash string, contact *Contact) (string, bool) {
+	msg := Message{
+		MsgType: "FIND",
+		Content: hash,
+		Sender:  network.RoutingTable.me,
+		Target:  *contact,
+	}
+	response, err := network.sendMessage(msg, contact)
+	if err != nil {
+		return ("Failed to contact target node."), false
+	}
+	var dataResponse string
+	err = json.Unmarshal(response, &dataResponse)
+	if err != nil {
+		return "Error during unmarshalling", false
+	} else if dataResponse == "" {
+		return "Data not found", false
+	} else {
+		return dataResponse, true
+	}
+}
+
+

--- a/kademlia/network.go
+++ b/kademlia/network.go
@@ -54,7 +54,7 @@ func (network *Network) Listen(ip string, port int) error {
 	}
 }
 
-func (network *Network) SendMessage(msg Message, contact *Contact) ([]byte, error) {
+func (network *Network) sendMessage(msg Message, contact *Contact) ([]byte, error) {
 	conn, err := net.Dial("udp", contact.Address)
 	if err != nil {
 		fmt.Printf("%s %s %s\n", contact.ID, "not responding", err.Error())
@@ -89,7 +89,7 @@ func (network *Network) SendPingMessage(target *Contact) bool {
 		Sender:  network.Me,
 	}
 
-	responseMsg, err := network.SendMessage(msg, target)
+	responseMsg, err := network.sendMessage(msg, target)
 	if err != nil {
 		fmt.Printf("%s %s %s\n", target.ID, "not responding", err.Error())
 		return false
@@ -112,7 +112,7 @@ func (network *Network) SendJoinMessage(contact *Contact) bool {
 		Sender:  network.Me,
 	}
 
-	responseMsg, err := network.SendMessage(msg, contact)
+	responseMsg, err := network.sendMessage(msg, contact)
 	if err != nil {
 		fmt.Printf("%s %s %s\n", contact.ID, "not responding", err.Error())
 		return false
@@ -135,7 +135,7 @@ func (network *Network) SendFindContactMessage(contact *Contact, targetID *Kadem
 		Sender:  network.Me,
 	}
 
-	contactsByte, err := network.SendMessage(msg, contact)
+	contactsByte, err := network.sendMessage(msg, contact)
 	if err != nil {
 		fmt.Printf("%s %s %s\n", contact.ID, "not responding", err.Error())
 		return nil, err
@@ -159,7 +159,7 @@ func (network *Network) SendFindDataMessage(hash string, contact *Contact) (stri
 		Sender:  network.RoutingTable.me,
 		Target:  *contact,
 	}
-	response, err := network.SendMessage(msg, contact)
+	response, err := network.sendMessage(msg, contact)
 	if err != nil {
 		return ("Failed to contact target node."), false
 	}
@@ -182,7 +182,7 @@ func (network *Network) SendStoreMessage(data []byte, key string, contact *Conta
 		Sender:  network.RoutingTable.me,
 		Target:  *contact,
 	}
-	responseMsg, err := network.SendMessage(msg, contact)
+	responseMsg, err := network.sendMessage(msg, contact)
 	if err != nil {
 		fmt.Printf("%s %s %s\n", contact.ID, "not responding", err.Error())
 		return false

--- a/kademlia/network_test.go
+++ b/kademlia/network_test.go
@@ -8,23 +8,68 @@ import (
 
 
 func TestNetwork(t *testing.T) {
-	contact1 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
+	contact1 := NewContact(NewKademliaID("1000000000000000000000000000000000000000"), "localhost:8001")
 	network1 := NewNetwork(contact1)
 
-	contact2 := NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8001")
+	contact2 := NewContact(NewKademliaID("2000000000000000000000000000000000000000"), "localhost:8002")
 	network2 := NewNetwork(contact2)
 
-	t.Run("Test SendPingMessage", func(t *testing.T) {
+	contact3 := NewContact(NewKademliaID("3000000000000000000000000000000000000000"), "localhost:8003")
+
+
+	t.Run("Test Listen", func(t *testing.T) {
 		go func (){
-			err := network2.Listen("0.0.0.0", 8001)
+			err := network2.Listen("0.0.0.0", 8002)
 			assert.Nil(t, err)
 		}()
-
-		//time.Sleep(1 * time.Second)
-
-		response := network1.SendPingMessage(&contact2)
-		assert.True(t, response)
 	})
 
+
+	t.Run("Test SendPingMessage", func(t *testing.T) {
+		response := network1.SendPingMessage(&contact2)
+		assert.True(t, response)
+
+		response = network1.SendPingMessage(&contact3)
+		assert.False(t, response)
+	})
+
+	t.Run("Test SendJoinMessage", func(t *testing.T) {
+		//Result: contact1 is added to contact2's routing table
+		response := network1.SendJoinMessage(&contact2)
+		assert.True(t, response)
+
+		//Result: contact3 is not added to contact2's routing table
+		response = network1.SendJoinMessage(&contact3)
+		assert.False(t, response)
+	})
+
+	t.Run("Test SendFindContactMessage", func(t *testing.T) {
+		//Result: contact1 is found in contact2's routing table
+		contacts, err := network1.SendFindContactMessage(&contact2, contact1.ID)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(contacts))
+		assert.Equal(t, contact1, contacts[0])
+
+		//Result: contact1 is not found in contact3's routing table
+		contacts, err = network1.SendFindContactMessage(&contact3, contact1.ID)
+		assert.NotNil(t, err)
+		assert.Equal(t, 0, len(contacts))
+
+		//Result: contact1 is found in contact2's routing table
+		contacts, err = network1.SendFindContactMessage(&contact2, contact3.ID)
+		assert.Nil(t, err)
+		assert.NotContains(t, contacts, contact3)
+	})
+
+	/*
+	//TODO: Implement this test
+	t.Run("Test SendStoreDataMessage", func(t *testing.T) {
+		//Result: data is stored in contact2's routing table
+		sha1 := sha1.Sum([]byte("data"))
+		key := hex.EncodeToString(sha1[:])
+		response := network1.SendStoreMessage([]byte("data"), key, &contact2)
+		assert.True(t, response)
+	})
+	*/
 }
 

--- a/kademlia/network_test.go
+++ b/kademlia/network_test.go
@@ -1,0 +1,30 @@
+package kademlia
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestNetwork(t *testing.T) {
+	contact1 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
+	network1 := NewNetwork(contact1)
+
+	contact2 := NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8001")
+	network2 := NewNetwork(contact2)
+
+	t.Run("Test SendPingMessage", func(t *testing.T) {
+		go func (){
+			err := network2.Listen("0.0.0.0", 8001)
+			assert.Nil(t, err)
+		}()
+
+		//time.Sleep(1 * time.Second)
+
+		response := network1.SendPingMessage(&contact2)
+		assert.True(t, response)
+	})
+
+}
+

--- a/kademlia/routingtable.go
+++ b/kademlia/routingtable.go
@@ -1,7 +1,5 @@
 package kademlia
 
-import "fmt"
-
 const bucketSize = 20
 
 
@@ -27,7 +25,7 @@ func (routingTable *RoutingTable) AddContact(contact Contact) {
 	bucketIndex := routingTable.getBucketIndex(contact.ID)
 	bucket := routingTable.buckets[bucketIndex]
 	bucket.AddContact(contact)
-	fmt.Println("Added contact: ", contact)
+	//fmt.Println("Added contact: ", contact)
 }
 
 // FindClosestContacts finds the count closest Contacts to the target in the RoutingTable

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -1,12 +1,8 @@
 package kademlia
 
-import (
-	"testing"
-)
-
 // FIXME: This test doesn't actually test anything. There is only one assertion
 // that is included as an example.
-
+/*
 func TestRoutingTable(t *testing.T) {
 	rt := NewRoutingTable(NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000"))
 
@@ -22,10 +18,12 @@ func TestRoutingTable(t *testing.T) {
 	for i := range contacts {
 		fmt.Println(contacts[i].String())
 	}
-	*/
-
+*/
+/*
 	// TODO: This is just an example. Make more meaningful assertions.
 	if len(contacts) != 6 {
 		t.Fatalf("Expected 6 contacts but instead got %d", len(contacts))
 	}
 }
+
+*/

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -1,29 +1,48 @@
 package kademlia
 
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
 // FIXME: This test doesn't actually test anything. There is only one assertion
 // that is included as an example.
-/*
+
 func TestRoutingTable(t *testing.T) {
-	rt := NewRoutingTable(NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000"))
+	contact1 := NewContact(NewKademliaID("1000000000000000000000000000000000000000"), "localhost:8000")
+	contact2 := NewContact(NewKademliaID("2000000000000000000000000000000000000000"), "localhost:8000")
+	contact3 := NewContact(NewKademliaID("3000000000000000000000000000000000000000"), "localhost:8000")
+	contact4 := NewContact(NewKademliaID("4000000000000000000000000000000000000000"), "localhost:8000")
+	contact5 := NewContact(NewKademliaID("5000000000000000000000000000000000000000"), "localhost:8000")
+	contact6 := NewContact(NewKademliaID("6000000000000000000000000000000000000000"), "localhost:8000")
+	rt := NewRoutingTable(contact1)
+	rt.AddContact(contact2)
+	rt.AddContact(contact3)
+	rt.AddContact(contact4)
+	rt.AddContact(contact5)
+	rt.AddContact(contact6)
 
-	rt.AddContact(NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8001"))
-	rt.AddContact(NewContact(NewKademliaID("1111111100000000000000000000000000000000"), "localhost:8002"))
-	rt.AddContact(NewContact(NewKademliaID("1111111200000000000000000000000000000000"), "localhost:8002"))
-	rt.AddContact(NewContact(NewKademliaID("1111111300000000000000000000000000000000"), "localhost:8002"))
-	rt.AddContact(NewContact(NewKademliaID("1111111400000000000000000000000000000000"), "localhost:8002"))
-	rt.AddContact(NewContact(NewKademliaID("2111111400000000000000000000000000000000"), "localhost:8002"))
+	t.Run("Test FindClosestContacts", func(t *testing.T) {
+		contacts := rt.FindClosestContacts(contact2.ID, 1)
+		assert.Equal(t, 1, len(contacts))
+		assert.Equal(t, contact2.ID, contacts[0].ID)
 
-	contacts := rt.FindClosestContacts(NewKademliaID("2111111400000000000000000000000000000000"), 20)
-	/*
-	for i := range contacts {
-		fmt.Println(contacts[i].String())
-	}
-*/
-/*
-	// TODO: This is just an example. Make more meaningful assertions.
-	if len(contacts) != 6 {
-		t.Fatalf("Expected 6 contacts but instead got %d", len(contacts))
-	}
+		contacts2 := rt.FindClosestContacts(contact2.ID, 3)
+		assert.Equal(t, 3, len(contacts2))
+		assert.Equal(t, contact2.ID, contacts2[0].ID)
+
+		contacts3 := rt.FindClosestContacts(contact2.ID, 10)
+		assert.Equal(t, 5, len(contacts3))
+		assert.Equal(t, contact2.ID, contacts3[0].ID)
+
+		for i := 1; i < len(contacts3); i++ {
+			assert.True(t, contacts3[i-1].distance.Less(contacts3[i].distance))
+		}
+
+		for i := 0; i < len(contacts2); i++ {
+			assert.Equal(t, contacts2[i], contacts3[i])
+		}
+	})
 }
 
-*/

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -1,7 +1,6 @@
 package kademlia
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -19,9 +18,11 @@ func TestRoutingTable(t *testing.T) {
 	rt.AddContact(NewContact(NewKademliaID("2111111400000000000000000000000000000000"), "localhost:8002"))
 
 	contacts := rt.FindClosestContacts(NewKademliaID("2111111400000000000000000000000000000000"), 20)
+	/*
 	for i := range contacts {
 		fmt.Println(contacts[i].String())
 	}
+	*/
 
 	// TODO: This is just an example. Make more meaningful assertions.
 	if len(contacts) != 6 {


### PR DESCRIPTION
Unit tests for the existing functionality on main. Current coverage: 70.7%. There are test files for all files (not counting doc.go since it's empty). Have done minor changes to dev files for fix bugs and improve testing, nothing major that causes merge conflicts. Example of fixes is making SendMessage a private function to Network and changing Start in Kademlia to use the contacts existing adress instead of hard coding it to localhost:3000.

To test: use `go test -v ./kademlia -cover` in root of project. 
Needed to get `golang.org/x/tools/cmd/cover` to be able to use the cover flag.