### PR TITLE
32 populate buckets evenly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 # command line flags, in order to actually get any replicas started. That
 # command requires that a docker swarm is already running in order to function.
 
-version: "3"
+#version: "3"
 services:
   kademliaNodes:
     image: kadlab:latest # Make sure your Docker image has this name.
@@ -13,7 +13,7 @@ services:
     tty: true
     deploy:
       mode: replicated
-      replicas: 50  
+      replicas: 50
       resources:
         limits:
           cpus: "0.1"
@@ -37,7 +37,7 @@ services:
       - kademlia_network
 
   bootstrapNode:
-    image: kadlab:latest 
+    image: kadlab:latest
     stdin_open: true
     tty: true
     deploy:
@@ -64,5 +64,4 @@ services:
 
 networks:
   kademlia_network:
-    driver:
-      bridge
+    driver: bridge

--- a/kademlia/cli/cli.go
+++ b/kademlia/cli/cli.go
@@ -30,6 +30,8 @@ func Kcli(input string, node *kademlia.Kademlia) {
 			} else {
 				fmt.Println("This comman needs one additional arguments")
 			}
+		case "print":
+			node.Network.RoutingTable.PrintRoutingTable()
 		case "exit":
 			fmt.Println("shutting down node...")
 			os.Exit(0)

--- a/kademlia/kademlia.go
+++ b/kademlia/kademlia.go
@@ -69,10 +69,15 @@ func (kademlia *Kademlia) JoinNetwork(knownNode *Contact) {
 	fmt.Println("Network joined.")
 	kademlia.PopulateNetwork()
 	kademlia.Network.RoutingTable.PrintRoutingTable()
+
+	time.Sleep(20 * time.Second)
+	kademlia.Network.RoutingTable.PrintRoutingTable()
 }
 
 func (kademlia *Kademlia) PopulateNetwork() {
 	fmt.Println("Populating the network...")
+
+	queriedNodes := []Contact{kademlia.Me}
 
 	// Define the number of random IDs to search for and populate the network with
 	for i := 0; i < IDLength*8; i++ { //2*i+1 Results in 8 iterations
@@ -83,15 +88,20 @@ func (kademlia *Kademlia) PopulateNetwork() {
 			continue
 		}
 
-		for _, contact := range contacts {
+		for _, contact := range contacts { //TODO: still contacts same mode multiple times?
+			if containsContact(queriedNodes, contact) {
+				continue
+			}
+			queriedNodes = append(queriedNodes, contact)
 			err = kademlia.Network.SendPingMessage(&contact)
 			if err != nil {
 				fmt.Println("Error pinging contact during network population, node may be down")
 			}else {
 				kademlia.Network.RoutingTable.AddContact(contact)
+				kademlia.Network.SendJoinMessage(&contact)
 			}
 		}
-		fmt.Printf("Found %d contacts for ID %s\n", len(contacts), id.String())
+		fmt.Printf("Found %d contacts for Bucket %d\n", len(contacts), i)
 	}
 
 	fmt.Println("Network population complete.")

--- a/kademlia/kademlia_test.go
+++ b/kademlia/kademlia_test.go
@@ -1,7 +1,6 @@
 package kademlia
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -35,6 +34,5 @@ func TestKademlia(t *testing.T) {
 		contacts, err := node.LookupContact(NewKademliaID("B0075712A9000000000000000000000000000000"))
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(contacts))
-		fmt.Println(contacts)
 	})
 }

--- a/kademlia/kademliaid.go
+++ b/kademlia/kademliaid.go
@@ -67,3 +67,9 @@ func (kademliaID KademliaID) CalcDistance(target *KademliaID) *KademliaID {
 func (kademliaID *KademliaID) String() string {
 	return hex.EncodeToString(kademliaID[0:IDLength])
 }
+
+func (id *KademliaID) Copy() *KademliaID {
+    newID := KademliaID{}
+    copy(newID[:], id[:]) // Use copy to duplicate the ID's content
+    return &newID
+}

--- a/kademlia/routingtable.go
+++ b/kademlia/routingtable.go
@@ -86,6 +86,7 @@ func (routingTable *RoutingTable) GenerateIDForBucket(bucketIndex int) *Kademlia
 }
 
 func (routingTable *RoutingTable) PrintRoutingTable() {
+	count := 0
 	for i := 0; i < IDLength*8; i++ {
 		bucket := routingTable.buckets[i]
 		if bucket.Len() != 0 {
@@ -94,6 +95,8 @@ func (routingTable *RoutingTable) PrintRoutingTable() {
 		for elt := bucket.list.Front(); elt != nil; elt = elt.Next() {
 			contact := elt.Value.(Contact)
 			fmt.Println("Contact: ", contact)
+			count++
 		}
 	}
+	fmt.Println("Total contacts: ", count)
 }

--- a/kademlia/routingtable.go
+++ b/kademlia/routingtable.go
@@ -1,6 +1,7 @@
 package kademlia
 
-const bucketSize = 20
+//TODO: update bucketSize
+const bucketSize = 5
 
 
 // RoutingTable definition
@@ -68,4 +69,16 @@ func (routingTable *RoutingTable) getBucketIndex(id *KademliaID) int {
 	}
 
 	return IDLength*8 - 1
+}
+
+// GenerateIDForBucket generates an ID that falls into the specified bucket index
+func (routingTable *RoutingTable) GenerateIDForBucket(bucketIndex int) *KademliaID {
+	newID := routingTable.me.ID.Copy()
+
+	byteIndex := bucketIndex / 8
+	bitIndex := bucketIndex % 8
+
+	newID[byteIndex] ^= 1 << uint8(7-bitIndex) 
+
+	return newID
 }

--- a/kademlia/routingtable.go
+++ b/kademlia/routingtable.go
@@ -1,7 +1,9 @@
 package kademlia
 
+import "fmt"
+
 //TODO: update bucketSize
-const bucketSize = 5
+const bucketSize = 20
 
 
 // RoutingTable definition
@@ -81,4 +83,17 @@ func (routingTable *RoutingTable) GenerateIDForBucket(bucketIndex int) *Kademlia
 	newID[byteIndex] ^= 1 << uint8(7-bitIndex) 
 
 	return newID
+}
+
+func (routingTable *RoutingTable) PrintRoutingTable() {
+	for i := 0; i < IDLength*8; i++ {
+		bucket := routingTable.buckets[i]
+		if bucket.Len() != 0 {
+			fmt.Println("Bucket: ", i)
+		}
+		for elt := bucket.list.Front(); elt != nil; elt = elt.Next() {
+			contact := elt.Value.(Contact)
+			fmt.Println("Contact: ", contact)
+		}
+	}
 }

--- a/kademlia/routingtable.go
+++ b/kademlia/routingtable.go
@@ -28,7 +28,6 @@ func (routingTable *RoutingTable) AddContact(contact Contact) {
 	bucketIndex := routingTable.getBucketIndex(contact.ID)
 	bucket := routingTable.buckets[bucketIndex]
 	bucket.AddContact(contact)
-	//fmt.Println("Added contact: ", contact)
 }
 
 // FindClosestContacts finds the count closest Contacts to the target in the RoutingTable

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -1,7 +1,6 @@
 package kademlia
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,6 @@ func TestRoutingTable(t *testing.T) {
 			id := rt.GenerateIDForBucket(i)
 			bucket := rt.getBucketIndex(id)
 			assert.Equal(t, i, bucket)
-			fmt.Println("Generated ID: ", id)
 		}
 	})
 }

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -1,6 +1,7 @@
 package kademlia
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,13 +47,12 @@ func TestRoutingTable(t *testing.T) {
 	})
 
 	t.Run("Test GenerateIDForBucket", func(t *testing.T) {
-		for i := 0; i < IDLength*8; i++ {
+		for i := 0; i < IDLength*8; i=2*i+1 {
 			id := rt.GenerateIDForBucket(i)
 			bucket := rt.getBucketIndex(id)
 			assert.Equal(t, i, bucket)
+			fmt.Println("Generated ID: ", id)
 		}
-		
-		
 	})
 }
 

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -44,5 +44,15 @@ func TestRoutingTable(t *testing.T) {
 			assert.Equal(t, contacts2[i], contacts3[i])
 		}
 	})
+
+	t.Run("Test GenerateIDForBucket", func(t *testing.T) {
+		for i := 0; i < IDLength*8; i++ {
+			id := rt.GenerateIDForBucket(i)
+			bucket := rt.getBucketIndex(id)
+			assert.Equal(t, i, bucket)
+		}
+		
+		
+	})
 }
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	}
 	
 	contact := kademlia.NewContact(kademlia.NewRandomKademliaID(), localIP+":"+NodePort)
-	fmt.Println(contact.String())
+	fmt.Println("Me: " + contact.String())
 	fmt.Println("BootstrapIP: " + bootstrapIP) // TODO: remove
 
 	node := kademlia.NewKademlia(contact, IS_BOOTSTRAP)


### PR DESCRIPTION
Fixed so that buckets are evenly populated. It currently generated id for 8 different buckets (0, 1, 3, 7, 15, 31, 63, 127), and does a lookup for each of those ids.

It is not actively being tested in the test file since it would need to either be a very large network or add a lot of mocking code. i decided that this was not worth the effort.