### PR TITLE
37 using ping in buckets

### DIFF
--- a/kademlia/bucket.go
+++ b/kademlia/bucket.go
@@ -2,7 +2,6 @@ package kademlia
 
 import (
 	"container/list"
-	"fmt"
 )
 
 // bucket definition
@@ -36,7 +35,6 @@ func (bucket *bucket) AddContact(contact Contact) {
 		if bucket.list.Len() < bucketSize {
 			bucket.list.PushFront(contact)
 		} else {
-			fmt.Println("Bucket is full")
 			oldest := bucket.list.Back().Value.(Contact)
 			err := bucket.network.SendPingMessage(&oldest)
 			if err != nil { 

--- a/kademlia/bucket.go
+++ b/kademlia/bucket.go
@@ -2,6 +2,7 @@ package kademlia
 
 import (
 	"container/list"
+	"fmt"
 )
 
 // bucket definition
@@ -35,6 +36,7 @@ func (bucket *bucket) AddContact(contact Contact) {
 		if bucket.list.Len() < bucketSize {
 			bucket.list.PushFront(contact)
 		} else {
+			fmt.Println("Bucket is full")
 			oldest := bucket.list.Back().Value.(Contact)
 			err := bucket.network.SendPingMessage(&oldest)
 			if err != nil { 

--- a/kademlia/bucket.go
+++ b/kademlia/bucket.go
@@ -8,12 +8,14 @@ import (
 // contains a List
 type bucket struct {
 	list *list.List
+	network *Network
 }
 
 // newBucket returns a new instance of a bucket
-func newBucket() *bucket {
+func newBucket(network *Network) *bucket {
 	bucket := &bucket{}
 	bucket.list = list.New()
+	bucket.network = network
 	return bucket
 }
 
@@ -32,6 +34,13 @@ func (bucket *bucket) AddContact(contact Contact) {
 	if element == nil {
 		if bucket.list.Len() < bucketSize {
 			bucket.list.PushFront(contact)
+		} else {
+			oldest := bucket.list.Back().Value.(Contact)
+			err := bucket.network.SendPingMessage(&oldest)
+			if err != nil { 
+				bucket.list.Remove(bucket.list.Front())
+				bucket.list.PushFront(contact)
+			} 
 		}
 	} else {
 		bucket.list.MoveToFront(element)

--- a/kademlia/bucket_test.go
+++ b/kademlia/bucket_test.go
@@ -40,10 +40,12 @@ func TestBucket(t *testing.T) {
 
 	t.Run("Test FullBucket", func(t *testing.T) {
 
-		for i := 0; i < bucketSize; i++ {
+		for i := 0; i < bucketSize-3; i++ {
 			bucket.AddContact(NewContact(NewRandomKademliaID(), ""))
 		}
 		assert.Equal(t, bucket.Len(), bucketSize)
+
+		assert.Equal(t, bucket.list.Back().Value.(Contact), contact1)
 
 		newContact := NewContact(NewRandomKademliaID(), "")
 		bucket.AddContact(newContact)

--- a/kademlia/bucket_test.go
+++ b/kademlia/bucket_test.go
@@ -1,6 +1,7 @@
 package kademlia
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,8 @@ import (
 
 func TestBucket(t *testing.T) {
 	// Create a new bucket
-	bucket := newBucket()
+	//contact0 := NewContact(NewKademliaID("0000000000000000000000000000000000000000"), "localhost:8000")
+	bucket := newBucket(nil)
 
 	// Create a new contact
 	contact1 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
@@ -18,18 +20,11 @@ func TestBucket(t *testing.T) {
 	t.Run("Test AddContact", func(t *testing.T) {
 		// Add a contact to the bucket
 		bucket.AddContact(contact1)
+		assert.Equal(t, 1, bucket.Len())
 
-		// Check if the contact has been added to the bucket
-		if bucket.Len() != 1 {
-			t.Fatalf("Expected 1 contact but instead got %d", bucket.Len())
-		}
-
-		// Add another contact to the bucket
 		bucket.AddContact(contact2)
 		bucket.AddContact(contact3)
-		if bucket.Len() != 3 {
-			t.Fatalf("Expected 3 contact but instead got %d", bucket.Len())
-		}
+		assert.Equal(t, 3, bucket.Len())
 	})
 
 	t.Run("Test GetContactAndCalcDistance", func(t *testing.T) {
@@ -41,5 +36,14 @@ func TestBucket(t *testing.T) {
 		assert.Equal(t, contacts[2].distance, contact1.ID)
 		assert.Equal(t, contacts[1].distance, contact2.ID)
 		assert.Equal(t, contacts[0].distance, contact3.ID)
+	})
+
+	t.Run("Test FullBucket", func(t *testing.T) {
+
+		for i := 0; i < bucketSize; i++ {
+			bucket.AddContact(NewContact(NewRandomKademliaID(), ""))
+		}
+		fmt.Println(bucket.Len())
+		
 	})
 }

--- a/kademlia/bucket_test.go
+++ b/kademlia/bucket_test.go
@@ -1,7 +1,6 @@
 package kademlia
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +8,9 @@ import (
 
 func TestBucket(t *testing.T) {
 	// Create a new bucket
-	//contact0 := NewContact(NewKademliaID("0000000000000000000000000000000000000000"), "localhost:8000")
-	bucket := newBucket(nil)
+	contact0 := NewContact(NewKademliaID("0000000000000000000000000000000000000000"), "localhost:8000")
+	network := NewNetwork(contact0, nil)
+	bucket := newBucket(network)
 
 	// Create a new contact
 	contact1 := NewContact(NewKademliaID("FFFFFFFF00000000000000000000000000000000"), "localhost:8000")
@@ -43,7 +43,11 @@ func TestBucket(t *testing.T) {
 		for i := 0; i < bucketSize; i++ {
 			bucket.AddContact(NewContact(NewRandomKademliaID(), ""))
 		}
-		fmt.Println(bucket.Len())
-		
+		assert.Equal(t, bucket.Len(), bucketSize)
+
+		newContact := NewContact(NewRandomKademliaID(), "")
+		bucket.AddContact(newContact)
+		assert.Equal(t, bucket.Len(), bucketSize)
+		assert.Equal(t, bucket.list.Front().Value.(Contact), newContact)
 	})
 }

--- a/kademlia/kademlia.go
+++ b/kademlia/kademlia.go
@@ -224,7 +224,7 @@ func (kademlia *Kademlia) Store(data []byte) (string, error) {
 	location := NewKademliaID(key)
 	contacts, _ := kademlia.LookupContact(location)
 	if len(contacts) == 0 {
-		return "", fmt.Errorf("No contacts found")
+		return "", fmt.Errorf("no contacts found")
 	}
 	for _, contact := range contacts {
 		fmt.Println("Storing data at: ", location.String(), " on node: ", contact.Address)

--- a/kademlia/messageHandler.go
+++ b/kademlia/messageHandler.go
@@ -16,6 +16,9 @@ func (network *Network) HandleMessage(rawMsg []byte, recieverAddr *net.UDPAddr) 
 		return nil, err
 	}
 
+	//adding the sender to the routing table
+	network.RoutingTable.AddContact(msg.Sender)
+
 	switch msg.MsgType {
 	case "PING":
 		response := network.handlePingMessage()

--- a/kademlia/network.go
+++ b/kademlia/network.go
@@ -22,7 +22,7 @@ func NewNetwork(me Contact, kademlia *Kademlia) *Network {
 	network := &Network{}
 	network.kademlia = kademlia
 	network.Me = me
-	network.RoutingTable = *NewRoutingTable(me)
+	network.RoutingTable = *NewRoutingTable(me, network)
 	return network
 }
 

--- a/kademlia/routingtable.go
+++ b/kademlia/routingtable.go
@@ -9,14 +9,16 @@ const bucketSize = 20
 type RoutingTable struct {
 	me      Contact
 	buckets [IDLength * 8]*bucket
+	network  *Network
 }
 
 // NewRoutingTable returns a new instance of a RoutingTable
-func NewRoutingTable(me Contact) *RoutingTable {
+func NewRoutingTable(me Contact, network *Network) *RoutingTable {
 	routingTable := &RoutingTable{}
 	for i := 0; i < IDLength*8; i++ {
-		routingTable.buckets[i] = newBucket()
+		routingTable.buckets[i] = newBucket(network)
 	}
+	routingTable.network = network
 	routingTable.me = me
 	return routingTable
 }

--- a/kademlia/routingtable_test.go
+++ b/kademlia/routingtable_test.go
@@ -16,7 +16,7 @@ func TestRoutingTable(t *testing.T) {
 	contact4 := NewContact(NewKademliaID("4000000000000000000000000000000000000000"), "localhost:8000")
 	contact5 := NewContact(NewKademliaID("5000000000000000000000000000000000000000"), "localhost:8000")
 	contact6 := NewContact(NewKademliaID("6000000000000000000000000000000000000000"), "localhost:8000")
-	rt := NewRoutingTable(contact1)
+	rt := NewRoutingTable(contact1, nil)
 	rt.AddContact(contact2)
 	rt.AddContact(contact3)
 	rt.AddContact(contact4)


### PR DESCRIPTION
Full buckets now ping the oldest node (the back of the list) to see if it is awake.. If it is awake the 21 node is discarded, if it is down the old node is discarded and the new node is added to the front of the list. Testing is added.

Issue https://github.com/SpiffiRacoon/group-12-kadlab/issues/39 (Receiving messages adds to routing table) was so small (like 3 lines), so I based this branch in it's branch and will add both to main at the same time.